### PR TITLE
[Fix] #63 splash 화면 안드로이드 12 이하 버전 에러 처리

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -6,23 +6,12 @@
         <type value="RUNNING_DEVICE_TARGET" />
         <deviceKey>
           <Key>
-            <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="$USER_HOME$/.android/avd/Pixel_2_API_33.avd" />
+            <type value="SERIAL_NUMBER" />
+            <value value="LMV350Nb62f79e8" />
           </Key>
         </deviceKey>
       </Target>
     </runningDeviceTargetSelectedWithDropDown>
-    <targetSelectedWithDropDown>
-      <Target>
-        <type value="QUICK_BOOT_TARGET" />
-        <deviceKey>
-          <Key>
-            <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="$USER_HOME$/.android/avd/Pixel_2_API_33.avd" />
-          </Key>
-        </deviceKey>
-      </Target>
-    </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-05-25T09:55:37.543649Z" />
+    <timeTargetWasSelectedWithDropDown value="2023-05-28T01:44:30.193303Z" />
   </component>
 </project>

--- a/app/src/main/java/org/sopar/presentation/login/LoginActivity.kt
+++ b/app/src/main/java/org/sopar/presentation/login/LoginActivity.kt
@@ -2,6 +2,7 @@ package org.sopar.presentation.login
 
 import android.animation.ObjectAnimator
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.view.animation.AnticipateInterpolator
@@ -48,19 +49,22 @@ class LoginActivity: AppCompatActivity() {
             }
         }
 
-        this.splashScreen.setOnExitAnimationListener { splashScreenView ->
-            val slideUp = ObjectAnimator.ofFloat(
-                splashScreenView,
-                View.TRANSLATION_Y,
-                0f,
-                -splashScreenView.height.toFloat()
-            )
-            slideUp.interpolator = AnticipateInterpolator()
-            slideUp.duration = 200L
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S){
+            this.splashScreen.setOnExitAnimationListener { splashScreenView ->
+                val slideUp = ObjectAnimator.ofFloat(
+                    splashScreenView,
+                    View.TRANSLATION_Y,
+                    0f,
+                    -splashScreenView.height.toFloat()
+                )
+                slideUp.interpolator = AnticipateInterpolator()
+                slideUp.duration = 200L
 
-            slideUp.doOnEnd { splashScreenView.remove() }
-            slideUp.start()
+                slideUp.doOnEnd { splashScreenView.remove() }
+                slideUp.start()
+            }
         }
+
     }
 
     private fun setObserver() {


### PR DESCRIPTION
## 무슨 기능인가요?
- splash 화면은 안드로이드 12부터 지원되는 api
- 이전 버전의 경우, splash api 에러 처리!

## Closes Issue
Closes Issue #63 