### PR TITLE
[Fix] #65 갤러리 권한 요청 시 발생하는 에러 처리

### DIFF
--- a/app/src/main/java/org/sopar/presentation/register/RegisterParkingLotImageFragment.kt
+++ b/app/src/main/java/org/sopar/presentation/register/RegisterParkingLotImageFragment.kt
@@ -37,7 +37,7 @@ class RegisterParkingLotImageFragment: BaseFragment<FragmentRegisterParkingLotIm
     private fun setListener() {
 
         binding.imageParkingLot.setOnClickListener {
-            if (Build.VERSION.SDK_INT>= Build.VERSION_CODES.Q) {
+            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
                 requestGalleryLauncher.launch(REQUIRED_GALLERY_PERMISSION)
             } else {
                 requestGalleryLauncher.launch(REQUIRED_EXTERNAL_STORAGE)
@@ -45,7 +45,7 @@ class RegisterParkingLotImageFragment: BaseFragment<FragmentRegisterParkingLotIm
         }
 
         binding.imageGallery.setOnClickListener {
-            if (Build.VERSION.SDK_INT>= Build.VERSION_CODES.Q) {
+            if (Build.VERSION.SDK_INT> Build.VERSION_CODES.Q) {
                 requestGalleryLauncher.launch(REQUIRED_GALLERY_PERMISSION)
             } else {
                 requestGalleryLauncher.launch(REQUIRED_EXTERNAL_STORAGE)

--- a/app/src/main/java/org/sopar/presentation/register/RegisterPermissionImageFragment.kt
+++ b/app/src/main/java/org/sopar/presentation/register/RegisterPermissionImageFragment.kt
@@ -82,7 +82,7 @@ class RegisterPermissionImageFragment: BaseFragment<FragmentRegisterPermissionIm
     private fun setListener() {
 
         binding.imageGallery.setOnClickListener {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
                 requestGalleryLauncher.launch(Constants.REQUIRED_GALLERY_PERMISSION)
             } else {
                 requestGalleryLauncher.launch(Constants.REQUIRED_EXTERNAL_STORAGE)
@@ -90,7 +90,7 @@ class RegisterPermissionImageFragment: BaseFragment<FragmentRegisterPermissionIm
         }
 
         binding.imageDocument.setOnClickListener {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            if (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
                 requestGalleryLauncher.launch(Constants.REQUIRED_GALLERY_PERMISSION)
             } else {
                 requestGalleryLauncher.launch(Constants.REQUIRED_EXTERNAL_STORAGE)


### PR DESCRIPTION
## 무슨 기능인가요?
android 10, 11에서 갤러리 권한을 물어보지 않는 문제 해결
```
if (Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
      requestGalleryLauncher.launch(REQUIRED_GALLERY_PERMISSION)
} else {
      requestGalleryLauncher.launch(REQUIRED_EXTERNAL_STORAGE)
}
```
- 부등호 `>=`에서 `>`으로 수정

## Closes Issue
Closes Issue #65 